### PR TITLE
Make TryLock::new const

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ pub struct TryLock<T> {
 impl<T> TryLock<T> {
     /// Create a `TryLock` around the value.
     #[inline]
-    pub fn new(val: T) -> TryLock<T> {
+    pub const fn new(val: T) -> TryLock<T> {
         TryLock {
             is_locked: AtomicBool::new(false),
             value: UnsafeCell::new(val),


### PR DESCRIPTION
I was playing with allocators and wanted a lightweight lock to protect some state. I found this crate, works great. Only complaint is that to initialize a GlobalAllocator, I needed `::new()` to be `const`. I made a small change here and it works!

`TryLock::new` calls two other functions, but is otherwise already `const`-able.

- [`AtomicBool::new`](https://doc.rust-lang.org/stable/std/sync/atomic/struct.AtomicBool.html#method.new), `const` since 1.24
- [`UnsafeCell::new`](https://doc.rust-lang.org/stable/std/cell/struct.UnsafeCell.html#method.new), `const` since 1.32

Since both functions have been `const` for a long time, I would be surprised if this change breaks anyone's code. Most projects track the latest stable Rust, so in my opinion this is fine.

I also tried `const`ing other functions, but it does not work on stable. The big blocker are the `panic!()` calls in `TryLock::try_lock_explicit_unchecked`. I didn't need anything else to be `const`, so I left everything else alone.
