### PR TITLE
Fix unsound lock guard: Remove Send and Sync autotraits from the lock guard

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ use core::cell::UnsafeCell;
 use core::fmt;
 use core::ops::{Deref, DerefMut};
 use core::sync::atomic::{AtomicBool, Ordering};
+use core::marker::PhantomData;
 
 /// A light-weight lock guarded by an atomic boolean.
 ///
@@ -167,6 +168,7 @@ impl<T> TryLock<T> {
             Some(Locked {
                 lock: self,
                 order: unlock_order,
+                _p: PhantomData,
             })
         } else {
             None
@@ -224,6 +226,8 @@ impl<T: fmt::Debug> fmt::Debug for TryLock<T> {
 pub struct Locked<'a, T: 'a> {
     lock: &'a TryLock<T>,
     order: Ordering,
+    /// Suppresses Send and Sync autotraits for `struct Locked`.
+    _p: PhantomData<*mut T>,
 }
 
 impl<'a, T> Deref for Locked<'a, T> {


### PR DESCRIPTION
Having Send on the lock guard is unsound. (Or at least it doesn't make any sense to send a lock guard to another thread).
Having Sync on the lock guard is unsound, unless T is Sync.

Normally this should use negative trait impls to get rid of Send and Sync.
However, negative trait impls are not fully stabilized, yet.
Use a phantom pointer instead. That's a bit overly strict in that it also removes Sync, if T is Sync.
But I think that's a low price to pay.

The following code exploits the bug:
```rust
use std::cell::Cell;
use std::sync::Arc;
use std::thread::sleep;
use std::time::Duration;
use try_lock::TryLock;

fn main() {
    let lock = Arc::new(TryLock::new(Cell::new(42_i32)));
    let guard = lock.try_lock().expect("try_lock failed.");

    const LOOP: usize = 10000;

    let _ = crossbeam::scope(|scope| {
        scope.spawn(|_| { // First thread
            for _ in 0..LOOP {
                guard.set(guard.get() + 1);
                sleep(Duration::from_micros(1));
            }
        });
        scope.spawn(|_| { // Second thread
            for _ in 0..LOOP {
                guard.set(guard.get() - 1);
                sleep(Duration::from_micros(1));
            }
        });
    });

    println!("{}", guard.get());
}
```

Without the bug fix, the printed value sometimes differs from the expected result 42 due to races.
With the bug fix applied, the code doesn't compile anymore. (as is expected, because the guard usage is unsound.)

The bug had also been present in stdlib MutexGuard. See this for a detailed explanation:

https://www.ralfj.de/blog/2017/06/09/mutexguard-sync.html
