### PR TITLE
Use portable-atomic

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,6 +15,14 @@ jobs:
           - beta
           - nightly
           - 1.31.0
+        features:
+          - ""
+          - --all-features
+        exclude:
+          # portable-atomics needs 1.34
+          - rust: 1.31.0
+            features: --all-features
+
 
     runs-on: ubuntu-latest
 
@@ -33,3 +41,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+          args: ${{ matrix.features }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ documentation = "https://docs.rs/try-lock"
 readme = "README.md"
 
 [dependencies]
+portable-atomic = { version = "1.3.0", default-features = false, features = ["require-cas"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,7 @@ documentation = "https://docs.rs/try-lock"
 readme = "README.md"
 
 [dependencies]
-portable-atomic = { version = "1.3.0", default-features = false, features = ["require-cas"] }
+# Enables the use on platforms without atomic CAS. This is a feature and not
+# on-by-default to account for the MSRV 1.31; when that version is increased,
+# this may become an unconditional dependency for simplicity.
+portable-atomic = { version = "1.3.0", default-features = false, features = ["require-cas"], optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,12 +46,16 @@
 #[cfg(test)]
 extern crate core;
 
+#[cfg(feature = "portable-atomic")]
 extern crate portable_atomic;
 
 use core::cell::UnsafeCell;
 use core::fmt;
 use core::ops::{Deref, DerefMut};
+#[cfg(feature = "portable-atomic")]
 use portable_atomic::AtomicBool;
+#[cfg(not(feature = "portable-atomic"))]
+use core::sync::atomic::AtomicBool;
 use core::sync::atomic::Ordering;
 use core::marker::PhantomData;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,10 +46,13 @@
 #[cfg(test)]
 extern crate core;
 
+extern crate portable_atomic;
+
 use core::cell::UnsafeCell;
 use core::fmt;
 use core::ops::{Deref, DerefMut};
-use core::sync::atomic::{AtomicBool, Ordering};
+use portable_atomic::AtomicBool;
+use core::sync::atomic::Ordering;
 use core::marker::PhantomData;
 
 /// A light-weight lock guarded by an atomic boolean.


### PR DESCRIPTION
This should not have run-time impact on platforms that support atomic boolean compare-and-swap, but enables its use on microcontrollers where the user configures portable-atomic in such a way that atomics can be emulated (eg. through disabling interrupts).

I have not tested whether portable-atomics works with the 1.31 version tested in CI. Should that fail, should I rather feature-gate this, can we update the MSRV of this crate, or should I hack CI to use an older version of portable-atomics (because Rust 1.31 was way before cargo became rust-version aware)?